### PR TITLE
Change build URLs

### DIFF
--- a/app/404.html
+++ b/app/404.html
@@ -16,8 +16,8 @@
 			}
 		</script>
 
-		<link href="//build.origami.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6,o-techdocs,o-grid,o-forms,o-buttons" rel="stylesheet">
-		<link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">
+		<link href="https://build.origami.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6,o-techdocs,o-grid,o-forms,o-buttons" rel="stylesheet">
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">
 
 		<!-- build:css styles/main.css -->
 		<link rel="stylesheet" href="styles/main.css">
@@ -57,7 +57,7 @@
 
 		<div class="information">
 			<div class="logo">
-				<img src="http://image.webservices.ft.com/v1/images/raw/fticon:brand-ft?width=250&amp;source=docs&amp;tint=333333,333333">
+				<img src="https://image.webservices.ft.com/v1/images/raw/fticon:brand-ft?width=250&amp;source=docs&amp;tint=333333,333333">
 			</div>
 			<div class="person-of-interest">
 				<h3 class="person-of-interest-target">David Cameron</h3>

--- a/app/404.html
+++ b/app/404.html
@@ -16,7 +16,7 @@
 			}
 		</script>
 
-		<link href="https://build.origami.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6,o-techdocs,o-grid,o-forms,o-buttons" rel="stylesheet">
+		<link href="https://origami-build.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6,o-techdocs,o-grid,o-forms,o-buttons" rel="stylesheet">
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">
 
 		<!-- build:css styles/main.css -->

--- a/app/erdos.html
+++ b/app/erdos.html
@@ -16,8 +16,8 @@
 			}
 		</script>
 
-		<link href="https://build.origami.ft.com/v1/bundles/css?modules=o-fonts%401.8.4%2Co-ft-icons%402.4.0%2Co-techdocs%404.2.1%2Co-grid%403.2.6%2Co-forms%401.0.3%2Co-buttons%403.0.3%2Co-autoinit%401.2.0&shrinkwrap=ftdomdelegate%402.0.3%2Co-assets%402.0.0%2Co-colors%403.3.1%2Co-dom%401.0.0%2Co-header%403.0.6%2Co-hierarchical-nav%402.1.4%2Co-hoverable%401.2.0%2Co-layers%401.1.2%2Co-squishy-list%401.2.0%2Co-viewport%401.5.0" rel="stylesheet">
-		<link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">
+		<link href="https://origami-build.ft.com/v1/bundles/css?modules=o-fonts%401.8.4%2Co-ft-icons%402.4.0%2Co-techdocs%404.2.1%2Co-grid%403.2.6%2Co-forms%401.0.3%2Co-buttons%403.0.3%2Co-autoinit%401.2.0&shrinkwrap=ftdomdelegate%402.0.3%2Co-assets%402.0.0%2Co-colors%403.3.1%2Co-dom%401.0.0%2Co-header%403.0.6%2Co-hierarchical-nav%402.1.4%2Co-hoverable%401.2.0%2Co-layers%401.1.2%2Co-squishy-list%401.2.0%2Co-viewport%401.5.0" rel="stylesheet">
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">
 
 		<!-- build:css styles/main.css -->
 		<link rel="stylesheet" href="styles/main.css">

--- a/app/graph.html
+++ b/app/graph.html
@@ -16,8 +16,8 @@
 			}
 		</script>
 
-		<link href="//build.origami.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6,o-techdocs,o-grid,o-forms,o-buttons" rel="stylesheet">
-		<link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">
+		<link href="https://origami-build.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6,o-techdocs,o-grid,o-forms,o-buttons" rel="stylesheet">
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">
 
 		<!-- build:css styles/main.css -->
 		<link rel="stylesheet" href="styles/main.css">
@@ -50,7 +50,7 @@
 
 		<div class="information">
 			<div class="logo">
-				<img src="http://image.webservices.ft.com/v1/images/raw/fticon:brand-ft?width=250&amp;source=docs&amp;tint=333333,333333">
+				<img src="https://image.webservices.ft.com/v1/images/raw/fticon:brand-ft?width=250&amp;source=docs&amp;tint=333333,333333">
 			</div>
 			<div class="person-of-interest">
 				<h3 class="person-of-interest-target">David Cameron</h3>

--- a/app/index.html
+++ b/app/index.html
@@ -16,8 +16,8 @@
 			}
 		</script>
 
-    <!-- https://build.origami.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6,o-techdocs@^4.0.1,o-grid@^3.0.0,o-forms@^1.0.0,o-buttons@^3.0.3 -->
-		<link href="https://build.origami.ft.com/v1/bundles/css?modules=o-fonts%401.8.4%2Co-ft-icons%402.4.0%2Co-techdocs%404.2.1%2Co-grid%403.2.6%2Co-forms%401.0.3%2Co-buttons%403.0.3%2Co-autoinit%401.2.0&shrinkwrap=ftdomdelegate%402.0.3%2Co-assets%402.0.0%2Co-colors%403.3.1%2Co-dom%401.0.0%2Co-header%403.0.6%2Co-hierarchical-nav%402.1.4%2Co-hoverable%401.2.0%2Co-layers%401.1.2%2Co-squishy-list%401.2.0%2Co-viewport%401.5.0" rel="stylesheet">
+    <!-- https://origami-build.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6,o-techdocs@^4.0.1,o-grid@^3.0.0,o-forms@^1.0.0,o-buttons@^3.0.3 -->
+		<link href="https://origami-build.ft.com/v1/bundles/css?modules=o-fonts%401.8.4%2Co-ft-icons%402.4.0%2Co-techdocs%404.2.1%2Co-grid%403.2.6%2Co-forms%401.0.3%2Co-buttons%403.0.3%2Co-autoinit%401.2.0&shrinkwrap=ftdomdelegate%402.0.3%2Co-assets%402.0.0%2Co-colors%403.3.1%2Co-dom%401.0.0%2Co-header%403.0.6%2Co-hierarchical-nav%402.1.4%2Co-hoverable%401.2.0%2Co-layers%401.1.2%2Co-squishy-list%401.2.0%2Co-viewport%401.5.0" rel="stylesheet">
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">
 
 		<!-- build:css styles/main.css -->


### PR DESCRIPTION
Origami Build Service is migrating from Akamai to Fastly.

@JakeChampion I added the `https://` links inside the files that had to be updated with the new build service URL. You might need to check the other files for `https://` in a future update.
